### PR TITLE
fix syntax for shapely version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     install_requires=[
         'numpy >= 1.2, < 2.0',
         'pandas >= 1.4, < 2.0',
-        'shapely >= 2 < 3.0',
+        'shapely >= 2, < 3.0',
         'geopandas >= 0.12.2, < 1.0',
         'morecantile >= 3.1, < 4.0',
         'Rtree >= 0.9, < 1.0',


### PR DESCRIPTION
inserted comma in shapely version requirement.

'shapely >= 2 < 3.0', --> 'shapely >= 2, < 3.0',