### PR TITLE
Merge neighbor dedup method 

### DIFF
--- a/pdgstaging/ConfigManager.py
+++ b/pdgstaging/ConfigManager.py
@@ -248,12 +248,7 @@ class ConfigManager():
                     option. If 'neighbor', then the input data will be 
                     deduplicated by removing nearby or overlapping polygons, 
                     as determined by the 'deduplicate_centroid_tolerance' and
-                    'deduplicate_overlap_tolerance' options. Note that with 
-                    release 0.9.0, the 'neighbor' method has been not been
-                    thoroughly tested. Only the 'footprints' method has been 
-                    thoroughly tested and should be applied to input data, 
-                    as this release is tailored to a dataset that requires 
-                    this deduplication method.
+                    'deduplicate_overlap_tolerance' options.
                 - deduplicate_keep_rules : list of tuple: []
                     Required for both deduplication methods. Rules that define
                     which of the polygons to keep when two or more are
@@ -300,9 +295,7 @@ class ConfigManager():
                     before calculating the distance between them.
                     centroid_tolerance will use the units of this CRS. Set to
                     None to skip the re-projection and use the CRS of the
-                    GeoDataFrame. Note that with release 0.9.0, 
-                    the 'neighbor' method has been not been thoroughly tested 
-                    and should not be applied to input data.
+                    GeoDataFrame.
                 - deduplicate_clip_to_footprint : bool, optional
                     For the 'footprints' deduplication method only. If True,
                     then polygons that fall outside the bounds of the

--- a/pdgstaging/ConfigManager.py
+++ b/pdgstaging/ConfigManager.py
@@ -1324,9 +1324,6 @@ class ConfigManager():
         """
         method = self.get('deduplicate_method')
         if(method == 'neighbor'):
-            logger.warning(f"Deduplication method 'neighbors' has not been"
-                           f"tested for release 0.9.0. Please use deduplication"
-                           f"method 'footprints' or None for this release.")
             return deduplicate_neighbors
         if(method == 'footprints'):
             return deduplicate_by_footprint

--- a/pdgstaging/Deduplicator.py
+++ b/pdgstaging/Deduplicator.py
@@ -690,10 +690,16 @@ def label_duplicates(deduplicate_output, prop_duplicated):
         else:
             # if the column `prop_duplicated` is not already present, 
             # create it and set all values to False
-            not_duplicates[prop_duplicated] = False
+            not_duplicates[prop_duplicated] = False 
 
     combined = pd.concat([not_duplicates, duplicates], ignore_index=True)
     combined.reset_index(drop=True, inplace=True)
+
+    if prop_duplicated not in combined.columns:
+        logger.warning(f"Config set to deduplicate but {prop_duplicated} col not in gdf.")
+    
+    if combined[prop_duplicated].isna().any():
+        logger.warning(f"{prop_duplicated} col has NA values.")
 
     return combined
 

--- a/pdgstaging/Deduplicator.py
+++ b/pdgstaging/Deduplicator.py
@@ -643,10 +643,12 @@ def deduplicate_by_footprint(
     if prop_duplicated in to_return.columns:
         if True in to_return[prop_duplicated].values:
             sum_true = (to_return[prop_duplicated] == True).value_counts()[True]
-            logger.info(f"Sum of True values in the {prop_duplicated} col is: {sum_true}")
+            logger.info(f"Sum of True values in the {prop_duplicated}"
+                        f" col is: {sum_true}")
         else:
             sum_true = 0
-            logger.info(f"Sum of True values in the {prop_duplicated} col is: {sum_true}")
+            logger.info(f"Sum of True values in the {prop_duplicated}" 
+                        f"col is: {sum_true}")
     else:
         logger.info(f"{prop_duplicated} is not a column present after labeling.")
 
@@ -696,12 +698,13 @@ def label_duplicates(deduplicate_output, prop_duplicated):
     combined.reset_index(drop=True, inplace=True)
 
     if prop_duplicated not in combined.columns:
-        error_msg = f"Config set to deduplicate but {prop_duplicated} col not in gdf after labeling dups."
-        logger.error(error_msg)
-        raise ValueError(error_msg)
+        msg = (f"Config set to dedup but {prop_duplicated} column"
+               f" not in gdf after labeling duplicates."
+               f"\nColumns are: {combined.columns}")
+        logger.info(msg)
     
     if combined[prop_duplicated].isna().any():
-        logger.warning(f"{prop_duplicated} col has NA values.")
+        logger.info(f"{prop_duplicated} column has NA values.")
 
     return combined
 

--- a/pdgstaging/Deduplicator.py
+++ b/pdgstaging/Deduplicator.py
@@ -208,7 +208,8 @@ def deduplicate_neighbors(
     return_intersections : bool, optional
         If True, the GeoDataFrame with the intersection geometries is returned
         in addition to the GeoDataFrames with the deduplicated and removed
-        geometries. Default is False.
+        geometries. Default is False. This option is not currently available in
+        this release.
     prop_duplicated : str, optional
         Defaults to "staging_duplicated". The column name / property to use to flag
         duplicates when label is True.
@@ -496,7 +497,7 @@ def deduplicate_by_footprint(
         This will be integrated again in releases after 0.9.0.
     """
 
-    logger.info(f"Executing deduplicate_by_footprint() for {gdf}")
+    logger.info(f"Executing footprint deduplication.")
 
     gdf = gdf.copy()
 

--- a/pdgstaging/Deduplicator.py
+++ b/pdgstaging/Deduplicator.py
@@ -696,7 +696,9 @@ def label_duplicates(deduplicate_output, prop_duplicated):
     combined.reset_index(drop=True, inplace=True)
 
     if prop_duplicated not in combined.columns:
-        logger.warning(f"Config set to deduplicate but {prop_duplicated} col not in gdf.")
+        error_msg = f"Config set to deduplicate but {prop_duplicated} col not in gdf after labeling dups."
+        logger.error(error_msg)
+        raise ValueError(error_msg)
     
     if combined[prop_duplicated].isna().any():
         logger.warning(f"{prop_duplicated} col has NA values.")

--- a/pdgstaging/TileStager.py
+++ b/pdgstaging/TileStager.py
@@ -560,6 +560,7 @@ class TileStager():
                         
                         # if dedup method is neighbors, add prop_duplicated col with values False
                         if dedup_method == "neighbor" and prop_duplicated not in data.columns:
+                            logger.info("Adding prop_duplicated column with False values to data.")
                             data[prop_duplicated] = False
                         
                         mode = 'w'
@@ -617,6 +618,15 @@ class TileStager():
             Nothing. Saves new tile in `staged` directory.
 
         """
+
+        # ensure data has staging_duplicated col if config set to deduplicate
+        dedup_method = self.config.get_deduplication_method()
+        prop_duplicated = self.config.polygon_prop('duplicated')
+        if dedup_method is not None and prop_duplicated not in data.columns:
+            error_msg = f"Config set to dedup, but prop_duplicated col not present in {data['staging_tile']} while saving tile."
+            logger.error(error_msg)
+            raise ValueError(error_msg)
+
         try: 
             # Ignore the FutureWarning raised from geopandas issue 2347
             with warnings.catch_warnings():

--- a/pdgstaging/TileStager.py
+++ b/pdgstaging/TileStager.py
@@ -527,25 +527,17 @@ class TileStager():
                         # If deduplicating by neighbor:
                         # the prop_duplicated col has not been created yet,
                         # so create it and set all values to False
-
-                        # dedup_start_time = datetime.now()
-                        # logger.info(f'Starting deduplication in tile {tile_path} with {len(gdf)}'
-                        #             'polygons.')
-                        # dedup_config = self.config.get_deduplication_config(gdf)
-                        # gdf = dedup_method(gdf, **dedup_config)
                         logger.info(f"Tile does not yet exist and config is set to deduplicate "
                                     f"at staging, so removing polygons that fell outside the footprint "
                                     f"if deduplicating by footpint, and removing overlapping polygons\n"
-                                    f"if deduplicating by neighbor if column already existed, and "
-                                    f"creating column with all false values it it did not exist.")
+                                    f"if deduplicating by neighbor if column already existed.\n "
+                                    f"Creating column with all false values it it did not exist.")
                         prop_duplicated = self.config.polygon_prop('duplicated')
-                        logger.info(f"Checking for presence of {prop_duplicated} col with dedup method set"
-                                    f" to {dedup_method}")
+                        logger.info(f"Checking for presence of {prop_duplicated} column.")
                         if prop_duplicated in data.columns:
                             data = data[~data[prop_duplicated]]
                         else:
-                            logger.info(f"Adding {prop_duplicated} column with False values to "
-                                        f"{data['staging_tile']}\nbecause property did not "
+                            logger.info(f"Adding {prop_duplicated} column because property did not "
                                         f"already exist.")
                             data[prop_duplicated] = False
 
@@ -569,20 +561,18 @@ class TileStager():
                         # with combine_and_deduplicate().
                         logger.info(f"Tile does not yet exist and config is set to deduplicate at a step "
                                     f"after staging, so just saving the new tile." 
-                                    f"\nIf deduplicating by footprint:\n"
+                                    f"\nIf deduplicating by footprint: "
                                     f"Duplicates from `clip_gdf` were identified.")
 
                         prop_duplicated = self.config.polygon_prop('duplicated')
-                        logger.info(f"Checking for presence of {prop_duplicated} col with dedup method set"
-                                    f" to {dedup_method}")
+                        logger.info(f"Checking for presence of {prop_duplicated} column.")
                         if prop_duplicated not in data.columns:
-                            logger.info(f"Adding {prop_duplicated} column with False values to "
-                                        f"{data['staging_tile']}\nbecause property did not "
+                            logger.info(f"Adding {prop_duplicated} column because property did not "
                                         f"already exist.")
                             data[prop_duplicated] = False
                         else:
-                            logger.info(f"File {data['staging_tile']} that did not yet exist did have "
-                                        f" {prop_duplicated} col before saving.")
+                            logger.info(f"Tile that did not yet exist did have "
+                                        f"{prop_duplicated} column before saving.")
                         
                         mode = 'w'
                         self.save_new_tile(data = data,

--- a/pdgstaging/TileStager.py
+++ b/pdgstaging/TileStager.py
@@ -519,9 +519,14 @@ class TileStager():
                 if dedup_method is not None:
                     if self.config.deduplicate_at('staging'):
                         # If the file does not yet exist and the config is set to deduplicate
-                        # at staging, just remove the polygons that were already labeled as 
+                        # at staging:
+                        # If deduplicatinf by footprint:
+                        # remove the polygons that were already labeled as 
                         # duplicates because they fell outside the footprint,
                         # and save the tile as a new tile.
+                        # If deduplicating by neighbor:
+                        # the prop_duplicated col has not been created yet,
+                        # so create it and set all values to False
 
                         # dedup_start_time = datetime.now()
                         # logger.info(f'Starting deduplication in tile {tile_path} with {len(gdf)}'
@@ -531,11 +536,18 @@ class TileStager():
                         logger.info(f"Tile does not yet exist and config is set to deduplicate "
                                     f"at staging, so removing polygons that fell outside the footprint "
                                     f"if deduplicating by footpint, and removing overlapping polygons\n"
-                                    f"if deduplicating by neighbor.")
-                        # retreive the name of the duplicated column from config
+                                    f"if deduplicating by neighbor if column already existed, and "
+                                    f"creating column with all false values it it did not exist.")
                         prop_duplicated = self.config.polygon_prop('duplicated')
+                        logger.info(f"Checking for presence of {prop_duplicated} col with dedup method set"
+                                    f" to {dedup_method}")
                         if prop_duplicated in data.columns:
                             data = data[~data[prop_duplicated]]
+                        else:
+                            logger.info(f"Adding {prop_duplicated} column with False values to "
+                                        f"{data['staging_tile']}\nbecause property did not "
+                                        f"already exist.")
+                            data[prop_duplicated] = False
 
                         mode = 'w'
                         self.save_new_tile(data = data,
@@ -560,11 +572,10 @@ class TileStager():
                                     f"\nIf deduplicating by footprint:\n"
                                     f"Duplicates from `clip_gdf` were identified.")
 
-                        dedup_method = self.config.get_deduplication_method()
                         prop_duplicated = self.config.polygon_prop('duplicated')
                         logger.info(f"Checking for presence of {prop_duplicated} col with dedup method set"
                                     f" to {dedup_method}")
-                        if dedup_method is not None and prop_duplicated not in data.columns:
+                        if prop_duplicated not in data.columns:
                             logger.info(f"Adding {prop_duplicated} column with False values to "
                                         f"{data['staging_tile']}\nbecause property did not "
                                         f"already exist.")


### PR DESCRIPTION
Reintroduce the neighbor deduplication method back into the workflow, with modifications to the deduplication method itself to match the changes made in the footprints method earlier, and checks introduced to `TileStager.py` for the presence of the `prop_duplicated` column in all staged tiles before saving.