### PR TITLE
Create a statistic to count the number of values within specified bounds

### DIFF
--- a/pdgstaging/ConfigManager.py
+++ b/pdgstaging/ConfigManager.py
@@ -185,7 +185,17 @@ class ConfigManager():
                         aggregation method will be used to summarize the given
                         property in the cell. Method can be any method allowed
                         in the 'func' property of the panda's aggregate method,
-                        e.g. 'sum', 'count', 'mean', etc.
+                        e.g. 'sum', 'count', 'mean', etc., or 'bounded_count'.
+                        For 'bounded_count', a 'bounds' tuple is required and
+                        'weight_by' is ignored because 'count' is already
+                        implied.
+                    - bounds : tuple
+                        An upper and lower bound for the value of 'property'
+                        for the element to be included in the count. Only
+                        used if 'aggregation_method' is 'bounded_count'. If one
+                        of the bounds is None, the accepted values for
+                        'property' are unbounded in that direction. The upper
+                        bound is inclusive and the lower bound is exclusive.
                     - resampling_method : str
                         The resampling method to use when combining raster data
                         from child tiles into parent tiles. See rasterio's
@@ -1163,11 +1173,13 @@ class ConfigManager():
             'name',
             'weight_by',
             'property',
-            'aggregation_method')
+            'aggregation_method',
+            'bounds'
+        )
         stats_config = []
         for stat_config in self.config['statistics']:
             stats_config.append(
-                {k: stat_config[k] for k in stats_config_keys}
+                {k: stat_config[k] for k in stats_config_keys if k in stat_config}
             )
 
         raster_config = {


### PR DESCRIPTION
Add a 'bounded_count' statistic and an associated 'bounds' field to the config. This can be used to create a custom statistic counting the number of vectors with a value for the specified property that is within the provided bounds.

For example, in the lake change dataset, to add statistics to count the number of expanding and shrinking lakes within each tile, the statistics entry in the config could include:

```
statistics = [
    {
      "name": "growing_lakes", 
      "property": "ChangeRateNet_myr-1", 
      "aggregation_method": "bounded_count", 
      "resampling_method": "sum",  
      "bounds": (0, None)
      # ... other standard fields related to display
    },
    {
      "name": "shrinking_lakes", 
      "property": "ChangeRateNet_myr-1", 
      "aggregation_method": "bounded_count", 
      "resampling_method": "sum",  
      "bounds": (None, 0)
      # ... other standard fields related to display
    },
]
```

The statistic itself will be handled in the viz-raster pipeline, so this PR shouldn't be merged until after https://github.com/PermafrostDiscoveryGateway/viz-raster/pull/35 in the viz-raster repository.