### PR TITLE
Add a step to create an evenly-spaced version of categorical values

### DIFF
--- a/pdgstaging/ConfigManager.py
+++ b/pdgstaging/ConfigManager.py
@@ -122,6 +122,13 @@ class ConfigManager():
             - simplify_tolerance : float
                 The tolerance to use when simplifying the input polygons.
                 Defaults to 0.0001. Set to None to skip simplification.
+            - categorical_values: dict
+                A dictionary mapping from the names of peroperties in the input
+                dataset representing categorical values to the order that the
+                values can be sorted into in order to be represented with
+                evenly-spaced values. This will be stored in a new column in
+                the staged dataset, with the prefix 'staged_normalized_' added
+                to the property's original name.
 
         - Tiling & rasterization options.
             - tms_id : str

--- a/pdgstaging/TileStager.py
+++ b/pdgstaging/TileStager.py
@@ -135,6 +135,7 @@ class TileStager():
             gdf = self.set_crs(gdf)
             self.grid = self.make_tms_grid(gdf)
             gdf = self.add_properties(gdf, path)
+            gdf = self.normalize_categorical_values(gdf)
             self.save_tiles(gdf)
         else:
             logger.warning(f'No features in {path}')
@@ -421,6 +422,34 @@ class TileStager():
             how='left',
             predicate='intersects',
             as_tile=True)
+
+    def normalize_categorical_values(self, gdf):
+        """
+            Add a column converting each 'categorical_value' defined in the
+            config to an evenly-spaced set of values.
+
+            Parameters
+            ----------
+            gdf: GeoDataFrame
+                The GeoDataFrame to add normalize the values for.
+
+            Returns
+            -------
+            GeoDataFrame
+                The GeoDataFrame with the normalized values added as a new
+                column.
+        """
+        categorical_values = self.config.get('categorical_values')
+        for categorical_value in categorical_values.items():
+            prop = categorical_value[0]
+            order = categorical_value[1]
+            value_map = {}
+            i = 1
+            for element in order:
+                value_map[element] = i
+                i += 1
+            gdf['staged_normalized_' + prop] = gdf[prop].map(value_map)
+        return gdf
 
     def make_tms_grid(self, gdf):
         """


### PR DESCRIPTION
Add a 'categorical_values' option to the config that will create alternate versions of the specified columns that have evenly-spaced values instead of the categorical values in the original column. For each property that represents a categorical value, this option must include all of the possible values and provide an order that the values should be sorted into.

For example, the [permafrost and ground ice dataset](https://github.com/PermafrostDiscoveryGateway/pdg-portal/issues/41#issuecomment-1632923316) includes a categorical EXTENT property that can have one of four values, represented by their first letter: Continuous, Discontinuous, Sporadic, Isolated patches. Adding the following 'categorical_values' option to the config will result in a new column (named staged_normalized_EXTENT) mapping those values to 4, 3, 2, and 1 respectively:
```
"categorical_values": {
  "EXTENT": ['I', 'S', 'D', 'C'],
},
```

So long as the list of all possible values for the column is known and specified, this should work for categorical properties of any data type, so it resolves #48.