### PR TITLE
Use the PEP621-standard project table name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-[tool.poetry]
+[project]
 name = "pdgstaging"
 version = "0.9.2"
 description = "Geospatial data tiling workflow"


### PR DESCRIPTION
While Poetry is not PEP621-compliant, that largely affects the dependency tables; Poetry can still understand the canonical `[project]` table.

I have some feelings about specifying package metadata (dependencies) in a tool-specific language rather than PEP621. Would you be open to adopting a PEP621-compliant build tool and allowing the user to use any tool they want for environment management?