### PR TITLE
Add GHA workflow to lint and pytest the package for issue #77

### DIFF
--- a/.github/workflows/python-lint-test.yaml
+++ b/.github/workflows/python-lint-test.yaml
@@ -16,8 +16,10 @@ jobs:
   lint-and-test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        os: [ubuntu-latest]
+        python-version: ["3.9", "3.12"]
+        #os: [ubuntu-latest, macos-latest]
+        #python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -35,11 +37,13 @@ jobs:
         if [ -f pyproject.toml ]; then uv sync ; fi
     - name: Lint with flake8
       run: |
+        source .venv/bin/activate
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
+        source .venv/bin/activate
         pytest
 

--- a/.github/workflows/python-lint-test.yaml
+++ b/.github/workflows/python-lint-test.yaml
@@ -17,9 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.12"]
-        #os: [ubuntu-latest, macos-latest]
-        #python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/python-lint-test.yaml
+++ b/.github/workflows/python-lint-test.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9"]
+        python-version: ["3.9", "3.12"]
         #os: [ubuntu-latest, macos-latest]
         #python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/python-lint-test.yaml
+++ b/.github/workflows/python-lint-test.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.9""]
         #os: [ubuntu-latest, macos-latest]
         #python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/python-lint-test.yaml
+++ b/.github/workflows/python-lint-test.yaml
@@ -1,0 +1,45 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python lint and test
+
+on:
+  push:
+    branches: [ "main", "develop" ]
+  pull_request:
+    branches: [ "main", "develop" ]
+
+permissions:
+  contents: read
+
+jobs:
+  lint-and-test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+          python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m venv .venv
+        source .venv/bin/activate
+        python -m pip install --upgrade pip
+        python -m pip install uv flake8 pytest
+        if [ -f pyproject.toml ]; then uv sync ; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest
+

--- a/.github/workflows/python-lint-test.yaml
+++ b/.github/workflows/python-lint-test.yaml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        uv sync --locked --all-extras --dev
+        uv sync --all-extras --dev
 
     - name: Lint with flake8
       run: |

--- a/.github/workflows/python-lint-test.yaml
+++ b/.github/workflows/python-lint-test.yaml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/python-lint-test.yaml
+++ b/.github/workflows/python-lint-test.yaml
@@ -24,17 +24,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+
+    - name: Install uv and set the Python version
+      uses: astral-sh/setup-uv@v6
       with:
-          python-version: ${{ matrix.python-version }}
+        python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
-        python -m venv .venv
-        source .venv/bin/activate
-        python -m pip install --upgrade pip
-        python -m pip install uv flake8 pytest
-        if [ -f pyproject.toml ]; then uv sync ; fi
+        uv sync --all-extras --dev
+
     - name: Lint with flake8
       run: |
         source .venv/bin/activate

--- a/.github/workflows/python-lint-test.yaml
+++ b/.github/workflows/python-lint-test.yaml
@@ -37,9 +37,9 @@ jobs:
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        uv run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        uv run flake8 pdgstaging --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        uv run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        uv run flake8 pdgstaging --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
         uv run pytest

--- a/.github/workflows/python-lint-test.yaml
+++ b/.github/workflows/python-lint-test.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install uv and set the Python version
       uses: astral-sh/setup-uv@v6
@@ -32,17 +32,15 @@ jobs:
 
     - name: Install dependencies
       run: |
-        uv sync --all-extras --dev
+        uv sync --locked --all-extras --dev
 
     - name: Lint with flake8
       run: |
-        source .venv/bin/activate
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        source .venv/bin/activate
         pytest
 

--- a/.github/workflows/python-lint-test.yaml
+++ b/.github/workflows/python-lint-test.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9""]
+        python-version: ["3.9"]
         #os: [ubuntu-latest, macos-latest]
         #python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/python-lint-test.yaml
+++ b/.github/workflows/python-lint-test.yaml
@@ -37,10 +37,10 @@ jobs:
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        uv run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        uv run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest
+        uv run pytest
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,13 +37,6 @@ dependencies = [
 [project.urls]
 Repository = "https://github.com/PermafrostDiscoveryGateway/viz-staging"
 
-[project.optional-dependencies]
-dev = [
-    "pytest >= 7",
-    "black >= 24.1.1",
-    "pre-commit >= 3.5.0",
-]
-
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
@@ -52,3 +45,11 @@ build-backend = "hatchling.build"
 line-length = 88
 target-version = ["py39"]
 include = "\\.pyi?$"
+
+[dependency-groups]
+dev = [
+    "flake8>=7.3.0",
+    "pytest >= 7",
+    "black >= 24.1.1",
+    "pre-commit >= 3.5.0",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 license = {text = "Apache Software License 2.0"}
 readme = "README.md"
-requires-python = ">= 3.9, < 3.10"
+requires-python = ">= 3.9"
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Intended Audience :: Developers",

--- a/tests/test_loaddata.py
+++ b/tests/test_loaddata.py
@@ -1,5 +1,5 @@
 from pandas import DataFrame
-from pdgstaging import ConfigManager
+from pdgstaging import TileStager
 
 
 def test_init():


### PR DESCRIPTION
Includes test fix to make the lone pdgstaging test pass. This demonstrates a GHA matrix workflow that runs both flake8 and pytest. Currently it is configured to run on ubuntu and macos, and across python minor versions from 3.9 to 3.13