### PR TITLE
Add checks to prevent race condition while running in parallel

### DIFF
--- a/pdgstaging/TilePathManager.py
+++ b/pdgstaging/TilePathManager.py
@@ -612,8 +612,8 @@ class TilePathManager:
 
         for path in paths:
             dir = os.path.dirname(path)
-            if dir and not os.path.exists(dir):
-                os.makedirs(dir)
+            if dir:
+                os.makedirs(dir, exist_ok=True)
 
     @staticmethod
     def remove_nonexistent_paths(paths):

--- a/pdgstaging/TileStager.py
+++ b/pdgstaging/TileStager.py
@@ -745,7 +745,7 @@ class TileStager:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", FutureWarning)
                 lock_path = str(tile_path) + ".lock"
-                with FileLock(lock_path, timeout=60):
+                with FileLock(lock_path, timeout=600, poll_interval=2.0):
                     data.to_file(tile_path, mode=mode)
 
             # convert each tile from string format to morecantile format

--- a/pdgstaging/TileStager.py
+++ b/pdgstaging/TileStager.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import random
 import time
 import uuid
 import warnings
@@ -14,7 +15,6 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 from filelock import FileLock
 from typing import Optional
-from filelock import FileLock
 
 from . import TilePathManager, TMSGrid
 
@@ -958,7 +958,7 @@ class TileStager:
         # Clean up DataFrame after writing
         del gdf_summary
 
-    def __lock_file(self, path):
+    def __lock_file(self, path, max_attempts=600, min_sleep=0.5, max_sleep=3.0):
         """
         Lock a file for writing.
 
@@ -972,25 +972,39 @@ class TileStager:
         lock : FileLock
             The lock object
         """
-        lock_path = path + ".lock"
+        lock_path = str(path) + ".lock"
         os.makedirs(os.path.dirname(lock_path), exist_ok=True)
 
-        lock = FileLock(lock_path)
-        lock.acquire()
-        return lock
+        for attempt in range(max_attempts):
+            try:
+                fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+                os.close(fd)
+                return lock_path 
+            except FileExistsError:
+                sleep_time = min_sleep + random.random() * (max_sleep - min_sleep)
+                self.logger.debug(
+                    f"Lock busy for {lock_path}, attempt {attempt + 1}/{max_attempts}, "
+                    f"retrying in {sleep_time:.1f}s"
+                )
+                time.sleep(sleep_time)
 
-    def __release_file(self, lock):
+        raise RuntimeError(
+            f"Could not acquire lock for {path} after {max_attempts} attempts "
+        )
+
+    def __release_file(self, lock_path):
         """
-        Release a file lock. Remove the lock file.
+        Release a file lock by removing the lock file.
 
         Parameters
         ----------
         lock : FileLock
             The lock to release
         """
-        lock.release()
-        if os.path.exists(lock.lock_file):
-            os.remove(lock.lock_file)
+        try:
+            os.remove(lock_path)
+        except OSError:
+            pass 
 
     def get_default_base_dir(self):
         """

--- a/pdgstaging/TileStager.py
+++ b/pdgstaging/TileStager.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import time
 import uuid
 import warnings
 import gc
@@ -501,6 +502,20 @@ class TileStager:
         grid.TILE_NAME = self.props["tile"]
         return grid
 
+    def _to_file_with_retry(self, data, tile_path, mode, attempts=8, base_sleep=0.2):
+        last = None
+        for i in range(attempts):
+            try:
+                data.to_file(tile_path, mode=mode)
+                return
+            except RuntimeError as e:
+                msg = str(e).lower()
+                if "database is locked" not in msg and "sqlite" not in msg:
+                    raise
+                last = e
+                time.sleep(base_sleep * (2**i))
+        raise last
+
     def save_tiles(
         self,
         gdf=None,
@@ -546,9 +561,11 @@ class TileStager:
 
             # Get the tile path
             tile_path = self.tiles.path_from_tile(tile, base_dir="staged")
-            self.tiles.create_dirs(tile_path)
-
-            # Lock the tile so that multiple processes don't try to write to
+            os.makedirs(os.path.dirname(tile_path), exist_ok=True)
+            try:
+                self.tiles.create_dirs(os.path.dirname(tile_path))
+            except Exception:
+                pass
             lock = self.__lock_file(tile_path)
 
             # Track the start time, the tile, and the number of vectors
@@ -741,12 +758,11 @@ class TileStager:
         """
 
         try:
-            # Ignore the FutureWarning raised from geopandas issue 2347
+            os.environ.setdefault("OGR_SQLITE_BUSY_TIMEOUT", "10000")
+            os.environ.setdefault("SQLITE_BUSY_TIMEOUT", "10000")
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", FutureWarning)
-                lock_path = str(tile_path) + ".lock"
-                with FileLock(lock_path, timeout=600, poll_interval=2.0):
-                    data.to_file(tile_path, mode=mode)
+                self._to_file_with_retry(data, tile_path, mode=mode)
 
             # convert each tile from string format to morecantile format
             # so it can be added to summary
@@ -957,11 +973,7 @@ class TileStager:
             The lock object
         """
         lock_path = path + ".lock"
-
-        # Ensure directory exists for lock file, to prevent race conditions
-        lock_dir = os.path.dirname(lock_path)
-        if lock_dir:
-            os.makedirs(lock_dir, exist_ok=True)
+        os.makedirs(os.path.dirname(lock_path), exist_ok=True)
 
         lock = FileLock(lock_path)
         lock.acquire()
@@ -1048,7 +1060,7 @@ class TileStager:
             base_dirs=self.base_dirs,
         )
 
-        return None
+        return self.tiles
 
     def csv_to_parquet(self):
         """

--- a/pdgstaging/TileStager.py
+++ b/pdgstaging/TileStager.py
@@ -13,6 +13,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 from filelock import FileLock
 from typing import Optional
+from filelock import FileLock
 
 from . import TilePathManager, TMSGrid
 
@@ -743,7 +744,9 @@ class TileStager:
             # Ignore the FutureWarning raised from geopandas issue 2347
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", FutureWarning)
-                data.to_file(tile_path, mode=mode)
+                lock_path = str(tile_path) + ".lock"
+                with FileLock(lock_path, timeout=60):
+                    data.to_file(tile_path, mode=mode)
 
             # convert each tile from string format to morecantile format
             # so it can be added to summary

--- a/pdgstaging/TileStager.py
+++ b/pdgstaging/TileStager.py
@@ -913,6 +913,12 @@ class TileStager:
             The lock object
         """
         lock_path = path + ".lock"
+
+        # Ensure directory exists for lock file, to prevent race conditions
+        lock_dir = os.path.dirname(lock_path)
+        if lock_dir:
+            os.makedirs(lock_dir, exist_ok=True)
+
         lock = FileLock(lock_path)
         lock.acquire()
         return lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdgstaging"
-version = "1.0.0"
+version = "1.1.0"
 description = "Geospatial data tiling workflow"
 authors = [
     {name = "Robyn Thiessen-Bock", email = "thiessenbock@nceas.ucsb.edu"},


### PR DESCRIPTION
Add checks to prevent race condition while running in parallel

Addresses the race-condition issue encountered while running in parallel.

Issue details:
error:
```error
FileNotFoundError: [Errno 2] No such file or directory: './output/staged/WGS1984Quad/3/0/1.gpkg.lock' .
```

traceback:
```
Traceback (most recent call last):
  File "/mnt/ceph/home/jeakadi/.pyenv/versions/merge-env/lib/python3.9/site-packages/parsl/dataflow/dflow.py", line 348, in handle_exec_update
    res = self._unwrap_remote_exception_wrapper(future)
  File "/mnt/ceph/home/jeakadi/.pyenv/versions/merge-env/lib/python3.9/site-packages/parsl/dataflow/dflow.py", line 612, in _unwrap_remote_exception_wrapper
    result.reraise()
  File "/mnt/ceph/home/jeakadi/.pyenv/versions/merge-env/lib/python3.9/site-packages/parsl/app/errors.py", line 114, in reraise
    raise v
  File "/mnt/ceph/home/jeakadi/.pyenv/versions/merge-env/lib/python3.9/site-packages/parsl/app/errors.py", line 138, in wrapper
    return func(*args, **kwargs)
  File "/mnt/ceph/home/jeakadi/pdg/surface-water-layer/runner-parsl.py", line 25, in stage
    wf.stage(path)
  File "/mnt/ceph/home/jeakadi/pdg/viz-workflow/pdgworkflow/WorkflowManager.py", line 180, in stage
    return self.tile_stager.stage(path=path)
  File "/mnt/ceph/home/jeakadi/.pyenv/versions/3.9.6/envs/merge-env/lib/python3.9/site-packages/pdgstaging/TileStager.py", line 149, in stage
    self.save_tiles(gdf)
  File "/mnt/ceph/home/jeakadi/.pyenv/versions/3.9.6/envs/merge-env/lib/python3.9/site-packages/pdgstaging/TileStager.py", line 551, in save_tiles
    lock = self.__lock_file(tile_path)
  File "/mnt/ceph/home/jeakadi/.pyenv/versions/3.9.6/envs/merge-env/lib/python3.9/site-packages/pdgstaging/TileStager.py", line 958, in __lock_file
    lock.acquire()
  File "/mnt/ceph/home/jeakadi/.pyenv/versions/3.9.6/envs/merge-env/lib/python3.9/site-packages/filelock/_api.py", line 332, in acquire
    self._acquire()
  File "/mnt/ceph/home/jeakadi/.pyenv/versions/3.9.6/envs/merge-env/lib/python3.9/site-packages/filelock/_unix.py", line 44, in _acquire
    fd = os.open(self.lock_file, open_flags, self._context.mode)
```